### PR TITLE
fix: broken links of linkedin and github

### DIFF
--- a/_data/json.yml
+++ b/_data/json.yml
@@ -53,8 +53,8 @@
     - value: Youtube
       url: https://youtube.com/@jatinkrmalik
     - value: LinkedIn
-      url: https://linkedin.com/in/jatinkmalik
+      url: https://linkedin.com/in/jatinkrmalik
     - value: GitHub
-      url: https://github.com/jatinkmalik
+      url: https://github.com/jatinkrmalik
     - value: "jatinkrmalik[at]gmail[dot]com"
       url: "mailto:jatinkrmalik@gmail.com"


### PR DESCRIPTION
@jatinkrmalik , I remember you told me once that I can search you on the whole internet with the username `jatinkrmalik` but just visiting you website and seeing the code of [j47.in](j47.in). I see that the there are broken links of github and linkedin in it.. So I fixed them.

btw, thanks Mr.Stark in Advance 😄 .

![image](https://github.com/user-attachments/assets/fcbeae0f-6823-4a9c-94af-fd3ffd2e0d8a)
